### PR TITLE
Validate UTF-8 in path before calling dropbox_write()

### DIFF
--- a/src/tdp-provider.c
+++ b/src/tdp-provider.c
@@ -186,6 +186,9 @@ static GList * tdp_provider_get_file_actions(
 		if(path == NULL)
 			continue;
 
+		if(!g_utf8_validate(path, -1, NULL))
+			continue;
+
 		dropbox_write(io_channel, "\t");
 		dropbox_write(io_channel, path);
 


### PR DESCRIPTION
Invalid UTF-8 caused G_IO_STATUS_ERROR in dropbox_write(), when a file
with such path was selected, which in turn resulted in 'crash'.