### PR TITLE
Reformat/tweak README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-`Thunar Dropbox`
-Thunar Dropbox is a plugin for thunar that adds context-menu items from 
-dropbox. This plugin does not come with dropbox itself, you will need to 
+# Thunar Dropbox
+
+Thunar Dropbox is a plugin for Thunar that adds context-menu items from 
+Dropbox. This plugin does not come with Dropbox itself, you will need to 
 install that separately.
 
 ![Thunar-Dropbox](http://softwarebakery.com/maato/images/thunardropbox_contextmenu.png)
 
-###Dependencies
+### Dependencies
 Depending on your distribution you might have to install 
-libthunarx-2
+`libthunarx-2`.
 
-###Installation from sources
+### Installation from sources
     python2 ./waf configure
     python2 ./waf build
     sudo python2 ./waf install


### PR DESCRIPTION
- Make the "Thunar Dropbox" heading an actual heading
- Fix broken headings due to missing space after `###`
- Capitalize Dropbox and Thunar